### PR TITLE
Simplfiy sending flowdock message

### DIFF
--- a/tasks/flowdock.yml
+++ b/tasks/flowdock.yml
@@ -26,26 +26,10 @@
               link="{{ flowdock_link }}"
               subject="Ansible Run Completed Successfully on {{ ansible_fqdn }}!" 
               source="ansible" from_name=ansible_{{ansible_user_id}} 
-              msg='ansible successful on {{ ansible_fqdn }} as {{ansible_env["SUDO_USER"]}}. IPv4={{ansible_default_ipv4["address"]}}/{{ansible_default_ipv4["netmask"]}}, IPv6={{ansible_default_ipv6["address"] | default("No IPv6")}}/{{ansible_default_ipv6["prefix"] | default("")}}, biosdate={{ansible_bios_date | default("N/A")}}, biosversion={{ansible_bios_version | default("N/A")}}, dist={{ansible_distribution}}, distversion={{ ansible_distribution_version }}, kernel={{ansible_kernel}}, memory={{ ansible_memtotal_mb}}, processor={{ansible_processor[1] | default("N/A")}}'
+              msg='ansible successful on {{ ansible_fqdn }} as {{ ansible_env["SUDO_USER"] | default(ansible_user_id) }}. IPv4={{ansible_default_ipv4["address"]}}/{{ansible_default_ipv4["netmask"]}}, IPv6={{ansible_default_ipv6["address"] | default("No IPv6")}}/{{ansible_default_ipv6["prefix"] | default("")}}, biosdate={{ansible_bios_date | default("N/A")}}, biosversion={{ansible_bios_version | default("N/A")}}, dist={{ansible_distribution}}, distversion={{ ansible_distribution_version }}, kernel={{ansible_kernel}}, memory={{ ansible_memtotal_mb}}, processor={{ansible_processor[1] | default("N/A")}}'
               tags='{{ansible_fqdn}},ansible,ok,{{ansible_domain}},{{siteName | default("siteName_undefined")}}' 
               token={{flowdock_token}}
     sudo: false
     always_run: yes
     when: not flowdock_chat
-    ignore_errors: True
-    register: flowdock_inbox_sent
-    changed_when: false
-
-  - name: 'send a inbox message to flowdock without sudo_user'
-    flowdock: type=inbox 
-              from_address={{ flowdock_from_address }} 
-              link="{{ flowdock_link }}"
-              subject="Ansible Run Completed Successfully on {{ ansible_fqdn }}!" 
-              source="ansible" from_name=ansible_{{ansible_user_id}} 
-              msg='ansible successful on {{ ansible_fqdn }} as {{ ansible_user_id }}. IPv4={{ansible_default_ipv4["address"]}}/{{ansible_default_ipv4["netmask"]}}, IPv6={{ansible_default_ipv6["address"] | default("No IPv6")}}/{{ansible_default_ipv6["prefix"] | default("")}}, biosdate={{ansible_bios_date | default("N/A")}}, biosversion={{ansible_bios_version | default("N/A")}}, dist={{ansible_distribution}}, distversion={{ ansible_distribution_version }}, kernel={{ansible_kernel}}, memory={{ ansible_memtotal_mb}}, processor={{ansible_processor[1] | default("N/A")}}'
-              tags='{{ansible_fqdn}},ansible,ok,{{ansible_domain}},{{siteName | default("siteName_undefined")}}'
-              token={{flowdock_token}}
-    sudo: false
-    always_run: yes
-    when: not flowdock_chat and flowdock_inbox_sent|failed
     changed_when: false


### PR DESCRIPTION
After
https://github.com/CSC-IT-Center-for-Science/fgci-ansible/commit/cc5b310cd110d903b552a7988e1350225fb74992
the command "ansible-playbook install.yml --tags=flowdock" started
failing, complaining that SUDO_USER wasn't found. This commit fixes
it, and at the same time simplifies the code.
